### PR TITLE
Support models with dynamic input/output shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ export ONNX_RUNTIME_LIB_DIR=$(brew --prefix onnxruntime)
 
 ## Testing
 
-Download the test model:
+Download the test models:
 
 ```shell
 curl -LO "https://github.com/onnx/models/raw/main/vision/classification/squeezenet/model/squeezenet1.0-8.onnx"
-curl -LO "https://github.com/onnx/models/raw/main/vision/classification/squeezenet/model/squeezenet1.0-12.onnx"
-curl -LO "https://github.com/onnx/models/raw/main/text/machine_comprehension/bert-squad/model/bertsquad-10.onnx"
 curl -LO "https://github.com/onnx/models/raw/main/vision/object_detection_segmentation/mask-rcnn/model/MaskRCNN-10.onnx"
 ```
 
@@ -41,11 +39,23 @@ request and the total time. To run the client:
 
 ```shell
 ❯ cargo run --bin client
-2023-04-11T02:34:51.750727Z  INFO client: src/client.rs:61: Input array: [1, 3, 224, 224]
-2023-04-11T02:34:52.192633Z  INFO client: src/client.rs:32: Success e1c0321f-1be8-4436-b5cf-d23ba9fd4976
+2023-04-19T18:31:32.023177Z  INFO client: src/bin/client.rs:112: Sending request for "squeezenet"
+2023-04-19T18:31:32.026326Z  INFO client: src/bin/client.rs:112: Sending request for "maskrcnn"
 ...
-2023-04-18T22:02:58.898530Z  INFO client: src/bin/client.rs:93: Total time: 1.831743333s
-2023-04-18T22:02:58.898539Z  INFO client: src/bin/client.rs:94: Average time: 1.028013755s
-2023-04-18T22:02:58.898547Z  INFO client: src/bin/client.rs:95: p95 time: 1.590004666s
-2023-04-18T22:02:58.898553Z  INFO client: src/bin/client.rs:96: p99 time: 1.730717125s
+2023-04-19T18:31:32.910031Z  INFO client: src/bin/client.rs:75: Success for model "squeezenet", prediction_id: 1ff1417e-5b8e-4fa7-8aff-5111fa50f3ac
+2023-04-19T18:31:33.722041Z  INFO client: src/bin/client.rs:75: Success for model "maskrcnn", prediction_id: 373fdc2c-8455-4b54-b7a5-f910ba1c506c
+...
+2023-04-19T18:32:00.538712Z  INFO client: src/bin/client.rs:143: Model: "squeezenet"
+2023-04-19T18:32:00.538725Z  INFO client: src/bin/client.rs:144: Total time: 13.100649499s
+2023-04-19T18:32:00.538734Z  INFO client: src/bin/client.rs:145: Average time: 524.025979ms
+2023-04-19T18:32:00.538742Z  INFO client: src/bin/client.rs:146: Median time: 551.289125ms
+2023-04-19T18:32:00.538750Z  INFO client: src/bin/client.rs:147: p95 time: 630.9305ms
+2023-04-19T18:32:00.538759Z  INFO client: src/bin/client.rs:148: p99 time: 680.362292ms
+...
+2023-04-19T18:32:00.538772Z  INFO client: src/bin/client.rs:143: Model: "maskrcnn"
+2023-04-19T18:32:00.538778Z  INFO client: src/bin/client.rs:144: Total time: 372.399760668s
+2023-04-19T18:32:00.538784Z  INFO client: src/bin/client.rs:145: Average time: 14.895990426s
+2023-04-19T18:32:00.538789Z  INFO client: src/bin/client.rs:146: Median time: 14.996715167s
+2023-04-19T18:32:00.538795Z  INFO client: src/bin/client.rs:147: p95 time: 27.056427083s
+2023-04-19T18:32:00.538801Z  INFO client: src/bin/client.rs:148: p99 time: 28.186501209s
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -6,9 +6,5 @@ server:
 models:
   - name: "squeezenet"
     path: "squeezenet1.0-8.onnx"
-  - name: "squeezenet2"
-    path: "squeezenet1.0-12.onnx"
-  # - name: "bertsquad"
-  #   path: "bertsquad-10.onnx"
-  # - name: "maskrcnn"
-  #   path: "MaskRCNN-10.onnx"
+  - name: "maskrcnn"
+    path: "MaskRCNN-10.onnx"

--- a/src/bin/onnx.rs
+++ b/src/bin/onnx.rs
@@ -1,9 +1,11 @@
+use ndarray::{ArrayView, Dim, IxDynImpl};
 use onnxruntime::{environment::Environment, ndarray::Array, GraphOptimizationLevel, LoggingLevel};
 use onnxruntime::tensor::OrtOwnedTensor;
 use lazy_static::{lazy_static, __Deref};
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
 use std::sync::Arc;
+use serde::Serialize;
 
 lazy_static! {
     pub static ref ENVIRONMENT: Arc<Environment> = Arc::new(
@@ -13,6 +15,11 @@ lazy_static! {
             .build()
             .unwrap()
     );
+}
+
+#[derive(Debug, Serialize)]
+struct Output<'a> {
+    data: ArrayView<'a, f32, Dim<IxDynImpl>>,
 }
 
 fn main() {
@@ -59,6 +66,10 @@ fn main() {
 
     let outputs: Vec<OrtOwnedTensor<f32, _>> = session.run(input_tensor_values).unwrap();
 
-    println!("output={:?}", &outputs[0].deref());
+    let output = Output{ data: outputs[0].deref().into() };
+
+    println!("output={:?}", output);
+
+    println!("json={:?}", serde_json::to_string(&output).unwrap());
 
 }

--- a/src/bin/onnx.rs
+++ b/src/bin/onnx.rs
@@ -1,0 +1,64 @@
+use onnxruntime::{environment::Environment, ndarray::Array, GraphOptimizationLevel, LoggingLevel};
+use onnxruntime::tensor::OrtOwnedTensor;
+use lazy_static::{lazy_static, __Deref};
+use tracing::Level;
+use tracing_subscriber::FmtSubscriber;
+use std::sync::Arc;
+
+lazy_static! {
+    pub static ref ENVIRONMENT: Arc<Environment> = Arc::new(
+        Environment::builder()
+            .with_name("onnx_environment")
+            .with_log_level(LoggingLevel::Warning)
+            .build()
+            .unwrap()
+    );
+}
+
+fn main() {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::TRACE)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    let mut session = ENVIRONMENT
+        .new_session_builder()
+        .unwrap()
+        .with_optimization_level(GraphOptimizationLevel::Basic)
+        .unwrap()
+        .with_number_threads(1)
+        .unwrap()
+        .with_model_from_file("squeezenet1.0-8.onnx")
+        .unwrap();
+
+    let input0_shape: Vec<usize> = session.inputs[0]
+        .dimensions()
+        .map(std::option::Option::unwrap)
+        .collect();
+    let output0_shape: Vec<usize> = session.outputs[0]
+        .dimensions()
+        .map(std::option::Option::unwrap)
+        .collect();
+
+    assert_eq!(input0_shape, [1, 3, 224, 224]);
+    assert_eq!(output0_shape, [1, 1000, 1, 1]);
+
+    // initialize input data with values in [0.0, 1.0]
+    let n: u32 = session.inputs[0]
+        .dimensions
+        .iter()
+        .map(|d| d.unwrap())
+        .product();
+
+    let array = Array::linspace(0.0_f32, 1.0, n as usize)
+        .into_shape(input0_shape)
+        .unwrap();
+
+    let input_tensor_values = vec![array.into()];
+
+    let outputs: Vec<OrtOwnedTensor<f32, _>> = session.run(input_tensor_values).unwrap();
+
+    println!("output={:?}", &outputs[0].deref());
+
+}

--- a/src/bin/onnx.rs
+++ b/src/bin/onnx.rs
@@ -2,7 +2,7 @@
 ///
 /// This script is used to test running an onnx session with a variety of
 /// models.
-#[allow(dead_code)]
+#[allow(dead_code, unused_variables)]
 use lazy_static::lazy_static;
 use ndarray::{Array, Dimension, IxDyn};
 use onnxruntime::tensor::OrtOwnedTensor;

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,6 @@
 use ndarray::{Array, IxDyn};
 use onnxruntime::environment::Environment;
 use onnxruntime::session::Session;
-use onnxruntime::tensor::OrtOwnedTensor;
 use onnxruntime::{GraphOptimizationLevel, LoggingLevel};
 use std::sync::Arc;
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,4 +1,4 @@
-use ndarray::Array4;
+use ndarray::{Array, IxDyn};
 use onnxruntime::environment::Environment;
 use onnxruntime::session::Session;
 use onnxruntime::tensor::OrtOwnedTensor;
@@ -51,14 +51,9 @@ impl Model<'_> {
         }
     }
 
-    pub fn predict(&mut self, inputs: Vec<Array4<f32>>) -> Vec<f32> {
+    pub fn predict(&mut self, inputs: Vec<Array<f32, IxDyn>>) -> Array<f32, IxDyn> {
         let outputs = self.session.run(inputs).unwrap();
-        let output: &OrtOwnedTensor<f32, _> = &outputs[0];
 
-        output
-            .softmax(ndarray::Axis(1))
-            .iter()
-            .copied()
-            .collect::<Vec<f32>>()
+        Array::from_shape_vec(outputs[0].shape(), outputs[0].iter().cloned().collect()).unwrap()
     }
 }

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -44,7 +44,11 @@ pub async fn handle_inference(
     requests_tx.send(message).await.unwrap();
     let response = response_rx.await.unwrap();
 
-    tracing::info!("Handler received prediction_id={:?}", prediction_id);
+    tracing::info!(
+        "Handler received prediction_id={:?} for model={}",
+        prediction_id,
+        &request.model_name
+    );
 
     Json(InferenceResponse {
         prediction_id,

--- a/src/predict.rs
+++ b/src/predict.rs
@@ -1,7 +1,7 @@
 use axum::extract::Extension;
 use axum::response::IntoResponse;
 use axum::Json;
-use ndarray::Array4;
+use ndarray::{Array, IxDyn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -13,14 +13,14 @@ use crate::worker::Message;
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InferenceRequest {
     pub model_name: String,
-    pub data: Array4<f32>,
+    pub data: Array<f32, IxDyn>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InferenceResponse {
     pub prediction_id: Uuid,
     pub model_name: String,
-    pub data: Vec<f32>,
+    pub data: Array<f32, IxDyn>,
 }
 
 pub async fn handle_inference(

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,4 +1,4 @@
-use ndarray::Array4;
+use ndarray::{Array, IxDyn};
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
 
@@ -9,8 +9,8 @@ use crate::model::Model;
 pub struct Message {
     pub prediction_id: Uuid,
     pub model_name: String,
-    pub input_data: Array4<f32>,
-    pub response_tx: oneshot::Sender<Vec<f32>>,
+    pub input_data: Array<f32, IxDyn>,
+    pub response_tx: oneshot::Sender<Array<f32, IxDyn>>,
 }
 
 pub struct InferenceWorker {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -36,13 +36,21 @@ impl InferenceWorker {
         loop {
             let request = requests_rx.blocking_recv().unwrap();
 
-            tracing::info!("Got prediction_id={:?}", request.prediction_id);
+            tracing::info!(
+                "InferenceWorker({:?}): got prediction_id={:?}",
+                &request.model_name,
+                request.prediction_id
+            );
 
             let output = model.predict(vec![request.input_data]);
 
             // Send the prediction back to the handler
-            let _ = request.response_tx.send(output);
-            tracing::info!("Sent prediction_id={:?}", request.prediction_id);
+            request.response_tx.send(output).unwrap();
+            tracing::info!(
+                "InferenceWorker({:?}): sent prediction_id={:?}",
+                &request.model_name,
+                request.prediction_id
+            );
         }
     }
 }


### PR DESCRIPTION
Previously, we only supported squeezenet as we had a fixed input size and assumed that the model was only returning a vector of `f32`. Change the internal representation of model inputs and outputs to accept an `Array<f32, IxDyn>` which is an array of dynamic dimensions that can be serialized and deseralized.

Updated the config to also host a maskrcnn model which is much more "expensive" than squeezenet. From the results of `client.rs`, we can see the per-model queues remove any contention between models with different performance characteristics:

```shell
2023-04-19T18:32:00.538712Z  INFO client: src/bin/client.rs:143: Model: "squeezenet"
2023-04-19T18:32:00.538725Z  INFO client: src/bin/client.rs:144: Total time: 13.100649499s
2023-04-19T18:32:00.538734Z  INFO client: src/bin/client.rs:145: Average time: 524.025979ms
2023-04-19T18:32:00.538742Z  INFO client: src/bin/client.rs:146: Median time: 551.289125ms
2023-04-19T18:32:00.538750Z  INFO client: src/bin/client.rs:147: p95 time: 630.9305ms
2023-04-19T18:32:00.538759Z  INFO client: src/bin/client.rs:148: p99 time: 680.362292ms
...
2023-04-19T18:32:00.538772Z  INFO client: src/bin/client.rs:143: Model: "maskrcnn"
2023-04-19T18:32:00.538778Z  INFO client: src/bin/client.rs:144: Total time: 372.399760668s
2023-04-19T18:32:00.538784Z  INFO client: src/bin/client.rs:145: Average time: 14.895990426s
2023-04-19T18:32:00.538789Z  INFO client: src/bin/client.rs:146: Median time: 14.996715167s
2023-04-19T18:32:00.538795Z  INFO client: src/bin/client.rs:147: p95 time: 27.056427083s
2023-04-19T18:32:00.538801Z  INFO client: src/bin/client.rs:148: p99 time: 28.186501209s
```